### PR TITLE
Adds explicit require for 'set' standard library

### DIFF
--- a/lib/manufacturable/registrar.rb
+++ b/lib/manufacturable/registrar.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 module Manufacturable
   class Registrar
     ALL_KEY = :__all__


### PR DESCRIPTION
The 'set' library needs to be explicitly required so that environment that don't already have it preloaded can use manufacturable