### PR TITLE
Adds Factory#builds?

### DIFF
--- a/lib/manufacturable.rb
+++ b/lib/manufacturable.rb
@@ -22,6 +22,10 @@ module Manufacturable
     Builder.build_all(*args, **kwargs, &block)
   end
 
+  def self.builds?(type, key)
+    Builder.builds?(type, key)
+  end
+
   def self.registered_types
     Registrar.registered_types
   end

--- a/lib/manufacturable/builder.rb
+++ b/lib/manufacturable/builder.rb
@@ -14,6 +14,10 @@ module Manufacturable
       self.new(*args, **kwargs, &block).build_all
     end
 
+    def self.builds?(*args, **kwargs, &block)
+      self.new(*args, **kwargs, &block).builds?
+    end
+
     def build
       return_first? ? instances.first : instances
     end
@@ -24,6 +28,10 @@ module Manufacturable
 
     def build_all
       instances
+    end
+
+    def builds?
+      Registrar.registered_keys(type).include?(key)
     end
 
     private

--- a/lib/manufacturable/factory.rb
+++ b/lib/manufacturable/factory.rb
@@ -27,5 +27,9 @@ module Manufacturable
 
       Builder.build_all(@type, key, *args)
     end
+
+    def builds?(key)
+      Builder.builds?(@type, key)
+    end
   end
 end

--- a/spec/manufacturable/builder_spec.rb
+++ b/spec/manufacturable/builder_spec.rb
@@ -266,4 +266,28 @@ RSpec.describe Manufacturable::Builder do
       end
     end
   end
+
+  describe '.builds?' do
+    subject(:builds?) { described_class.builds?(type, key) }
+
+    before do
+      allow(Manufacturable::Registrar).to receive(:registered_keys).with(type).and_return(registered_keys)
+    end
+
+    context 'when the key is registered for the type' do
+      let(:registered_keys) { [key] }
+
+      it 'returns true' do
+        expect(builds?).to eq(true)
+      end
+    end
+
+    context 'when the key is NOT registered for the type' do
+      let(:registered_keys) { [:different_key] }
+
+      it 'returns false' do
+        expect(builds?).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/manufacturable/factory_spec.rb
+++ b/spec/manufacturable/factory_spec.rb
@@ -94,4 +94,18 @@ RSpec.describe Manufacturable::Factory do
       end
     end
   end
+
+  describe '.builds?' do
+    subject(:builds?) { factory.builds?(key) }
+
+    before do
+      allow(Manufacturable::Builder).to receive(:builds?)
+      factory.manufactures(klass)
+      builds?
+    end
+
+    it 'delegates to the builder' do
+      expect(Manufacturable::Builder).to have_received(:builds?).with(klass, key)
+    end
+  end
 end

--- a/spec/manufacturable_spec.rb
+++ b/spec/manufacturable_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Manufacturable do
   end
 
   describe '.build' do
-    subject(:build) { Manufacturable.build(args) }
+    subject(:build) { described_class.build(args) }
 
     let(:args) { 'args' }
 
@@ -20,7 +20,7 @@ RSpec.describe Manufacturable do
   end
 
   describe '.build_one' do
-    subject(:build_one) { Manufacturable.build_one(args) }
+    subject(:build_one) { described_class.build_one(args) }
 
     let(:args) { 'args' }
 
@@ -36,7 +36,7 @@ RSpec.describe Manufacturable do
   end
 
   describe '.build_many' do
-    subject(:build_many) { Manufacturable.build_many(args) }
+    subject(:build_many) { described_class.build_many(args) }
 
     let(:args) { 'args' }
 
@@ -52,7 +52,7 @@ RSpec.describe Manufacturable do
   end
 
   describe '.build_all' do
-    subject(:build_all) { Manufacturable.build_all(args) }
+    subject(:build_all) { described_class.build_all(args) }
 
     let(:args) { 'args' }
 
@@ -67,8 +67,25 @@ RSpec.describe Manufacturable do
     end
   end
 
+  describe '.builds?' do
+    subject(:builds?) { described_class.builds?(type, key) }
+
+    let(:type) { :type }
+    let(:key) { :key }
+
+    before do
+      allow(Manufacturable::Builder).to receive(:builds?)
+
+      builds?
+    end
+
+    it 'delegates to the Builder' do
+      expect(Manufacturable::Builder).to have_received(:builds?).with(type, key)
+    end
+  end
+
   describe '.registered_types' do
-    subject(:registered_types) { Manufacturable.registered_types }
+    subject(:registered_types) { described_class.registered_types }
 
     before do
       allow(Manufacturable::Registrar).to receive(:registered_types)
@@ -82,7 +99,7 @@ RSpec.describe Manufacturable do
   end
 
   describe '.registered_keys' do
-    subject(:registered_keys) { Manufacturable.registered_keys(type) }
+    subject(:registered_keys) { described_class.registered_keys(type) }
 
     let(:type) { 'type' }
 
@@ -98,7 +115,7 @@ RSpec.describe Manufacturable do
   end
 
   describe '.reset!' do
-    subject(:reset!) { Manufacturable.reset! }
+    subject(:reset!) { described_class.reset! }
 
     before do
       allow(Manufacturable::Registrar).to receive(:reset!)
@@ -112,7 +129,7 @@ RSpec.describe Manufacturable do
   end
 
   describe '.config' do
-    subject(:config) { Manufacturable.config(&block) }
+    subject(:config) { described_class.config(&block) }
 
     let(:block) { Proc.new {} }
 
@@ -121,7 +138,7 @@ RSpec.describe Manufacturable do
     end
 
     it 'calls the block with the config class' do
-      Manufacturable.config { |arg| expect(arg).to eq(Manufacturable::Config) }
+      described_class.config { |arg| expect(arg).to eq(Manufacturable::Config) }
     end
 
     it 'loads the configured paths' do


### PR DESCRIPTION
Adds Factory#builds? so clients can check if a key can be built
Also adds Manufacturable.builds? as a convenience method.

Co-authored-by: Alan Ridlehoover <alan@ridlehoover.com>